### PR TITLE
Make `el-get` look for package customizations into `~/.emacs.d/init-PKGNAME.el`

### DIFF
--- a/init.el
+++ b/init.el
@@ -45,6 +45,10 @@
 ;; default el-get recipe to get around bugs.
 (add-to-list 'el-get-recipe-path "~/.emacs.d/ome-el-get-recipes")
 
+;; tell el-get to look into local customizations for every package into
+;; `~/.emacs.d/init-<package>.el'
+(setq el-get-user-package-directory "~/.emacs.d")
+
 ;; Some workaround for emacs version < 24.0, thanks Silthanis@github.
 (if (< emacs-major-version 24)
     (defun file-name-base (&optional filename)


### PR DESCRIPTION
`el-get` has a feature for automatically loading package init/customization code for package `foo` by loading `init-foo.el`.  This pull request enables this feature to add a new entry point for local package customization code.
