### PR TITLE
Update MELPA URL

### DIFF
--- a/init.el
+++ b/init.el
@@ -35,7 +35,7 @@
   ;; build melpa packages for el-get
   (el-get-install 'package)
   (setq package-archives '(("gnu" . "http://elpa.gnu.org/packages/")
-                           ("melpa" . "http://melpa.milkbox.net/packages/")))
+                           ("melpa" . "http://melpa.org/packages/")))
   (el-get-elpa-build-local-recipes))
 
 ;; enable git shallow clone to save time and bandwidth

--- a/ome.org
+++ b/ome.org
@@ -172,7 +172,7 @@ this is done by putting the following code snippet in =$HOME/.emacs.d/init.el=.
   ;; build melpa packages for el-get
   (el-get-install 'package)
   (setq package-archives '(("gnu" . "http://elpa.gnu.org/packages/")
-                           ("melpa" . "http://melpa.milkbox.net/packages/")))
+                           ("melpa" . "http://melpa.org/packages/")))
   (el-get-elpa-build-local-recipes))
 
 (add-to-list 'el-get-recipe-path "~/.emacs.d/ome-el-get-recipes")
@@ -188,10 +188,10 @@ default.
 By default, el-get bundles with about 1000 packages. Combined with elpa,
 there're about 3000 packages. However, many of them are outdated, unmaintained,
 lack of documentation. For elpa package archive, there are multiple choices,
-namely the official GNU [[http://elpa.gnu.org/][elpa]], [[http://marmalade-repo.org/][marmalade]] and [[http://melpa.milkbox.net/][melpa]], etc. [[http://elpa.gnu.org/][elpa]] is just too stable
+namely the official GNU [[http://elpa.gnu.org/][elpa]], [[http://marmalade-repo.org/][marmalade]] and [[http://melpa.org/][melpa]], etc. [[http://elpa.gnu.org/][elpa]] is just too stable
 which update just too little, and packages in [[http://marmalade-repo.org/][marmalade]] is a little outdated
 since it requires authors of packages to upload their package each time a
-new version is released. [[http://melpa.milkbox.net/][melpa]], similar to el-get, however, it builds packages
+new version is released. [[http://melpa.org/][melpa]], similar to el-get, however, it builds packages
 directly from package's source repository. To tell the truth, melpa is really
 quite a good alternative to el-get. Compared to el-get, there's no need to
 install =git=, =cvs=, =svn=, etc. You have =package.el=, then you can use


### PR DESCRIPTION
The URL for the MELPA has changed to http://melpa.org, the old URL
redirects to http://melpa.org
