### PR TITLE
Remove some dirty 'auto-complete' stuff sojourned in this company-features branch

### DIFF
--- a/modules/ome-emacs-lisp.org
+++ b/modules/ome-emacs-lisp.org
@@ -102,7 +102,7 @@ Start `ielm' if it's not already running."
   (ome-start-or-switch-to 'ielm "*ielm*"))
 
 (define-key emacs-lisp-mode-map (kbd "C-c C-z") 'ome-visit-ielm)
-(add-to-list 'ac-modes 'inferior-emacs-lisp-mode)
+;; (add-to-list 'ac-modes 'inferior-emacs-lisp-mode)
 (add-hook 'ielm-mode-hook 'ac-emacs-lisp-mode-setup)
 (add-hook 'ielm-mode-hook 'turn-on-eldoc-mode)
 #+END_SRC
@@ -128,7 +128,7 @@ about how to mastering eshell, see [[http://www.masteringemacs.org/articles/2010
           (lambda ()
             (add-to-list 'ac-sources 'ac-source-pcomplete)))
 
-(add-to-list 'ac-modes 'eshell-mode)
+;; (add-to-list 'ac-modes 'eshell-mode)
 (add-hook 'eshell-mode-hook 'turn-on-eldoc-mode)
 (add-hook 'eshell-mode-hook 'ac-emacs-lisp-mode-setup)
 #+END_SRC

--- a/modules/ome-ruby.org
+++ b/modules/ome-ruby.org
@@ -125,7 +125,7 @@ Basic features of robe:
 #+BEGIN_SRC emacs-lisp
 (defun ome-robe-mode-setup ()
   (add-hook 'robe-mode-hook 'ac-robe-setup)
-  (add-to-list 'ac-modes 'inf-ruby-mode)
+;;  (add-to-list 'ac-modes 'inf-ruby-mode)
   (add-hook 'inf-ruby-mode-hook 'ac-robe-setup))
 
 (ome-install 'robe-mode)


### PR DESCRIPTION
Actually I can't tell whether this is truly a  bug:

While I start a bare  installation, there was always some errors reported about `(add-to-list 'ac-modes 'inferior-emacs-lisp-mode)` and ` (add-hook 'robe-mode-hook 'ac-robe-setup)` .

I figured it should be none of the business of `auto-complete` in this company-featured branch,so I tried comment those lines related to `ac-modes` ,and finaly got a new company-featured Ome worked on my MBP.

I just wonder if that was a bug or that you just use ac-modes for ruby and emacs-lisp while using company for another modes!